### PR TITLE
fix plugin.yml authors syntax

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: SimplyVanish
 main: me.asofold.bpl.simplyvanish.SimplyVanish
 version: 1.3.1
-authors: asofold, jeikobu__
+authors: [asofold, jeikobu__]
 softdepend:
 - DisguiseCraft
 - dynmap


### PR DESCRIPTION
On 1.9 server startup, you would otherwise get

```
org.bukkit.plugin.InvalidDescriptionException: authors are of wrong type
    at org.bukkit.plugin.PluginDescriptionFile.loadMap(PluginDescriptionFile.java:995) ~[spigot-1.9.jar:git-Spigot-5a40365-7fc5cd8]
    at org.bukkit.plugin.PluginDescriptionFile.<init>(PluginDescriptionFile.java:232) ~[spigot-1.9.jar:git-Spigot-5a40365-7fc5cd8]
    at org.bukkit.plugin.java.JavaPluginLoader.getPluginDescription(JavaPluginLoader.java:159) ~[spigot-1.9.jar:git-Spigot-5a40365-7fc5cd8]
    at org.bukkit.plugin.SimplePluginManager.loadPlugins(SimplePluginManager.java:133) [spigot-1.9.jar:git-Spigot-5a40365-7fc5cd8]
    at org.bukkit.craftbukkit.v1_9_R1.CraftServer.loadPlugins(CraftServer.java:296) [spigot-1.9.jar:git-Spigot-5a40365-7fc5cd8]
    at net.minecraft.server.v1_9_R1.DedicatedServer.init(DedicatedServer.java:201) [spigot-1.9.jar:git-Spigot-5a40365-7fc5cd8]
    at net.minecraft.server.v1_9_R1.MinecraftServer.run(MinecraftServer.java:527) [spigot-1.9.jar:git-Spigot-5a40365-7fc5cd8]
    at java.lang.Thread.run(Thread.java:744) [?:1.7.0_45]
Caused by: java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Iterable
    at org.bukkit.plugin.PluginDescriptionFile.loadMap(PluginDescriptionFile.java:991) ~[spigot-1.9.jar:git-Spigot-5a40365-7fc5cd8]
    ... 7 more
```
